### PR TITLE
fix: correct typos in SQLtoPostgres modules (#31, #32)

### DIFF
--- a/SQLtoPostgres/00_-_Pre-Requisites.md
+++ b/SQLtoPostgres/00_-_Pre-Requisites.md
@@ -8,7 +8,7 @@
 
 <img style="float: left; margin: 0px 15px 15px 0px;" src="https://raw.githubusercontent.com/microsoft/sqlworkshops/master/graphics/textbubble.png"> <h2>00 – Pre-Requisites</h2>
 
-The **PostgreSQL for the SQL Server Database Professional** workshop is taught using the components listed below. You should install and configure each section *before* attending the workshop — there will not be time to complete setup during class. Note that in this pre-requisite, and in the entire course, you will switch between using various grpahical clients and also various command-line tools. This is inefficient, but will help you get familiarized with multiple tools. 
+The **PostgreSQL for the SQL Server Database Professional** workshop is taught using the components listed below. You should install and configure each section *before* attending the workshop — there will not be time to complete setup during class. Note that in this pre-requisite, and in the entire course, you will switch between using various graphical clients and also various command-line tools. This is inefficient, but will help you get familiarized with multiple tools. 
 
 *All examples in this workshop use Microsoft Windows as the base operating system. PostgreSQL runs natively on Windows, Linux, and macOS; the hands-on exercises will work on any platform, but screenshots and path examples reference Windows.*
 
@@ -84,7 +84,7 @@ $pgBin = "C:\Program Files\PostgreSQL\17\bin"
     "Machine"
 )
 ```
-Exit your terminal and start it back up again. Then connect to Postgres using the Command Line tool `pgsql`:
+Exit your terminal and start it back up again. Then connect to Postgres using the Command Line tool `psql`:
 
 ```bat
 psql --version

--- a/SQLtoPostgres/01_-_Introduction_and_Overview.md
+++ b/SQLtoPostgres/01_-_Introduction_and_Overview.md
@@ -63,7 +63,7 @@ SQL Server writes all changes to a per-database transaction log (`.ldf` file) be
 
 <p><img style="float: left; margin: 0px 15px 15px 0px;" src="https://raw.githubusercontent.com/microsoft/sqlworkshops/master/graphics/point1.png"><b>Activity 1.1 – Connect with psql and Explore the Cluster Hierarchy</b></p>
 
-In this activity you will use `psql` shich is Postgres's command-line client, to connect to your local cluster and explore the object hierarchy. This mirrors what you would do with `sqlcmd` in SQL Server.
+In this activity you will use `psql` which is Postgres's command-line client, to connect to your local cluster and explore the object hierarchy. This mirrors what you would do with `sqlcmd` in SQL Server.
 
 <p><img style="margin: 0px 15px 15px 0px;" src="https://raw.githubusercontent.com/microsoft/sqlworkshops/master/graphics/checkmark.png"><b>Steps</b></p>
 


### PR DESCRIPTION
## Summary
Correct three typos across two SQLtoPostgres module files, as described in issues #31 and #32.

## Changes
- **00_-_Pre-Requisites.md line 11**: `grpahical` → `graphical`
- **00_-_Pre-Requisites.md lines 87, 92**: `pgsql` → `psql` (correct CLI tool name)
- **01_-_Introduction_and_Overview.md line 66**: `shich` → `which`

## Verification
```bash
git diff --stat
# SQLtoPostgres/00_-_Pre-Requisites.md | 4 ++--
# SQLtoPostgres/01_-_Introduction_and_Overview.md | 2 +-
# 2 files changed, 3 insertions(+), 3 deletions(-)
```

Fixes #31 and #32.